### PR TITLE
add pass_rate display for OI mode

### DIFF
--- a/application/classes/Controller/Solution.php
+++ b/application/classes/Controller/Solution.php
@@ -55,7 +55,7 @@ class Controller_Solution extends Controller_Base
         $total = Model_Solution::count($filter);
 
         // view
-        $this->template_data['title'] = 'STATUS';
+        $this->template_data['title'] = 'Status';
         $this->template_data['list']  = $status;
         $this->template_data['total'] = ceil($total / $per_page);
 

--- a/application/classes/Model/Solution.php
+++ b/application/classes/Model/Solution.php
@@ -52,6 +52,7 @@ class Model_Solution extends Model_Base
         'num',
         'code_length',
         'judgetime',
+        'pass_rate',
     );
 
     public $solution_id;
@@ -68,6 +69,7 @@ class Model_Solution extends Model_Base
     public $num;
     public $code_length;
     public $judgetime;
+    public $pass_rate;
 
 
     /**
@@ -132,6 +134,13 @@ class Model_Solution extends Model_Base
     public function display_language()
     {
         return OJ::lang($this->language);
+    }
+
+    public function display_pass_rate()
+    {
+        return ($this->pass_rate > .98 ? 1 : $this->pass_rate) * 100;
+        // for legacy reason, in Google Code version,
+        // accepted will be recorded about .99
     }
 
     /**
@@ -264,6 +273,7 @@ class Model_Solution extends Model_Base
         $this->result = self::STATUS_PENDING;
         $this->valid = 1;
         $this->num = -1;
+        $this->pass_rate = 0;
     }
 
     public function validate()

--- a/application/classes/OJ.php
+++ b/application/classes/OJ.php
@@ -293,4 +293,9 @@ class OJ
             return '@.@';
         }
     }
+
+    public static function is_io_mode()
+    {
+        return Kohana::$config->load('base')->get('oi_mode', false);
+    }
 }

--- a/application/config/base.sample.php
+++ b/application/config/base.sample.php
@@ -9,4 +9,5 @@ return array(
     'domain'   => 'acm.hust.edu.cn',
     'base_url' => '/',
     'salt'     => 'hustoj',
+    'oi_mode'  => false,
 );

--- a/application/views/solution/status.php
+++ b/application/views/solution/status.php
@@ -42,7 +42,10 @@
         <td><?php echo $i->solution_id;?></td>
         <td><?php echo HTML::anchor("/problem/show/{$i->problem_id}", $i->problem_id);?></td>
         <td><?php echo HTML::anchor("/u/{$i->user_id}", $i->user_id);?></td>
-        <td><?php echo OJ::jresult($i->result);?></td>
+        <td>
+            <?php echo OJ::jresult($i->result);?>
+            <?php if (OJ::is_io_mode()) echo $i->display_pass_rate(); ?>
+        </td>
         <td><?php if($i->result == 4) echo $i->time, 'ms'; else echo('----');?></td>
         <td><?php if($i->result == 4) echo $i->memory, 'kb'; else echo('----');?></td>
         <td><?php echo OJ::lang($i->language);?></td>


### PR DESCRIPTION
oi_mode(pass_rate) support
a new column 'pass_rate' DECIMAL(2,2) UNSIGNED NOT NULL DEFAULT 0 in table solution for old HUSTOJ was required.

oi_mode(pass_rate) 支持
对于旧的 HUSTOJ，必须在 solution 表中增加一个一个空的列： 'pass_rate' DECIMAL(2,2) UNSIGNED NOT NULL DEFAULT 0。
